### PR TITLE
refactor: use ESM for eslint config files

### DIFF
--- a/complexity.js
+++ b/complexity.js
@@ -1,6 +1,5 @@
-"use strict";
-
-module.exports = [
+// biome-ignore lint/style/noDefaultExport: Required for ESLint configuration
+export default [
 	{
 		rules: {
 			"max-depth": ["warn", 2],

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,7 +1,0 @@
-"use strict";
-
-const complexity = require("./complexity.cjs");
-const groupImports = require("./groupImports.cjs");
-const nodeWithBiome = require("./nodeWithBiome.cjs");
-
-module.exports = [...nodeWithBiome, ...complexity, ...groupImports];

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,6 @@
+import complexity from "./complexity.js";
+import groupImports from "./groupImports.js";
+import nodeWithBiome from "./nodeWithBiome.js";
+
+// biome-ignore lint/style/noDefaultExport: Required for ESLint configuration
+export default [...nodeWithBiome, ...complexity, ...groupImports];

--- a/groupImports.js
+++ b/groupImports.js
@@ -1,6 +1,5 @@
-"use strict";
-
-module.exports = [
+// biome-ignore lint/style/noDefaultExport: Required for ESLint configuration
+export default [
 	{
 		rules: {
 			"sort-imports": [

--- a/node.js
+++ b/node.js
@@ -1,17 +1,16 @@
-"use strict";
+import stylistic from "@stylistic/eslint-plugin";
+import typescriptEslint from "@typescript-eslint/eslint-plugin";
+import tsParser from "@typescript-eslint/parser";
+import importPlugin, { flatConfigs } from "eslint-plugin-import";
+import jest from "eslint-plugin-jest";
+import react from "eslint-plugin-react";
+import reactHooks from "eslint-plugin-react-hooks";
+import testingLibrary from "eslint-plugin-testing-library";
+import unicorn from "eslint-plugin-unicorn";
+import globals from "globals";
 
-const stylistic = require("@stylistic/eslint-plugin");
-const typescriptEslint = require("@typescript-eslint/eslint-plugin");
-const tsParser = require("@typescript-eslint/parser");
-const importPlugin = require("eslint-plugin-import");
-const jest = require("eslint-plugin-jest");
-const react = require("eslint-plugin-react");
-const reactHooks = require("eslint-plugin-react-hooks");
-const testingLibrary = require("eslint-plugin-testing-library");
-const unicorn = require("eslint-plugin-unicorn");
-const globals = require("globals");
-
-module.exports = [
+// biome-ignore lint/style/noDefaultExport: Required for ESLint configuration
+export default [
 	{
 		plugins: {
 			"@stylistic": stylistic,
@@ -815,7 +814,7 @@ module.exports = [
 	},
 	{
 		files: ["**/*.ts", "**/*.tsx"],
-		...importPlugin.flatConfigs.typescript,
+		...flatConfigs.typescript,
 	},
 	{
 		files: ["**/*.ts", "**/*.tsx"],
@@ -827,7 +826,7 @@ module.exports = [
 			sourceType: "module",
 			parserOptions: {
 				projectService: true,
-				tsconfigRootDir: __dirname,
+				tsconfigRootDir: import.meta.dirname,
 			},
 		},
 		rules: {

--- a/nodeWithBiome.js
+++ b/nodeWithBiome.js
@@ -1,17 +1,16 @@
-"use strict";
+import stylistic from "@stylistic/eslint-plugin";
+import typescriptEslint from "@typescript-eslint/eslint-plugin";
+import tsParser from "@typescript-eslint/parser";
+import importPlugin, { flatConfigs } from "eslint-plugin-import";
+import jest from "eslint-plugin-jest";
+import react from "eslint-plugin-react";
+import reactHooks from "eslint-plugin-react-hooks";
+import testingLibrary from "eslint-plugin-testing-library";
+import unicorn from "eslint-plugin-unicorn";
+import globals from "globals";
 
-const stylistic = require("@stylistic/eslint-plugin");
-const typescriptEslint = require("@typescript-eslint/eslint-plugin");
-const tsParser = require("@typescript-eslint/parser");
-const importPlugin = require("eslint-plugin-import");
-const jest = require("eslint-plugin-jest");
-const react = require("eslint-plugin-react");
-const reactHooks = require("eslint-plugin-react-hooks");
-const testingLibrary = require("eslint-plugin-testing-library");
-const unicorn = require("eslint-plugin-unicorn");
-const globals = require("globals");
-
-module.exports = [
+// biome-ignore lint/style/noDefaultExport: Required for ESLint configuration
+export default [
 	{
 		plugins: {
 			"@stylistic": stylistic,
@@ -731,7 +730,7 @@ module.exports = [
 	},
 	{
 		files: ["**/*.ts", "**/*.tsx"],
-		...importPlugin.flatConfigs.typescript,
+		...flatConfigs.typescript,
 	},
 	{
 		files: ["**/*.ts", "**/*.tsx"],
@@ -743,7 +742,7 @@ module.exports = [
 			sourceType: "module",
 			parserOptions: {
 				projectService: true,
-				tsconfigRootDir: __dirname,
+				tsconfigRootDir: import.meta.dirname,
 			},
 		},
 		rules: {

--- a/package.json
+++ b/package.json
@@ -6,11 +6,11 @@
   "main": "index.js",
   "exports": {
     "./biome": "./biomeLinting.json",
-    "./node": "./node.cjs",
-    "./nodeWithBiome": "./nodeWithBiome.cjs",
-    "./complexity": "./complexity.cjs",
-    "./groupImports": "./groupImports.cjs",
-    "./reactNative": "./reactNative.cjs"
+    "./node": "./node.js",
+    "./nodeWithBiome": "./nodeWithBiome.js",
+    "./complexity": "./complexity.js",
+    "./groupImports": "./groupImports.js",
+    "./reactNative": "./reactNative.js"
   },
   "scripts": {
     "update": "npx -y npm-check-updates -i --install never && npx -y npm-check-updates -i --target minor --install never && npx -y npm-check-updates -i --target patch --install never && npm update --force",

--- a/reactNative.js
+++ b/reactNative.js
@@ -1,8 +1,7 @@
-"use strict";
+import reactNative from "eslint-plugin-react-native";
 
-const reactNative = require("eslint-plugin-react-native");
-
-module.exports = [
+// biome-ignore lint/style/noDefaultExport: Required for ESLint configuration
+export default [
 	{
 		plugins: {
 			"react-native": reactNative,


### PR DESCRIPTION
BREAKING CHANGE: The eslint config files are now in ESM format. This means that you need to use `import` and `export` instead of `module.exports` in your eslint config files.